### PR TITLE
remove unsupported from

### DIFF
--- a/gen_files.py
+++ b/gen_files.py
@@ -31,7 +31,6 @@ def gen_schema(node_name):
                             "not_null",
                             {
                                 "relationships": {
-                                    "from": "id",
                                     "to": "node_0",
                                     "field": "id"
                                 }


### PR DESCRIPTION
before this change dbt would throw an error like the following:
```
Encountered an error:
Compilation Error in test relationships_node_1779_id__id__id__node_0 (models/path_177/node_1779.yml)
  macro 'dbt_macro__test_relationships' takes no keyword argument 'from'
  > in macro test_relationships (macros/schema_tests/relationships.sql)
  > called by test relationships_node_1779_id__id__id__node_0 (models/path_177/node_1779.yml)
```